### PR TITLE
Fix "Install from fork/branch" install instructions to allow install from fork

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -51,7 +51,7 @@ INSTALL_BRANCH=develop
 
 curl -fsSL \
   https://raw.githubusercontent.com/$GITHUB_USER/swarmlet/$INSTALL_BRANCH/install |\
-  bash -s INSTALL_BRANCH=$INSTALL_BRANCH
+  bash -s INSTALL_BRANCH=$INSTALL_BRANCH SWARMLET_REPO="https://github.com/$GITHUB_USER/swarmlet.git"
 ```
 
 ## Installation options


### PR DESCRIPTION
Instructions present on Swarmlet website do not include overriding `SWARMLET_REPO`.

As it was, the installation file will be downloaded from the desired fork & branch, but the actual Swarmlet installation scripts will still be downloaded from the main swarmlet repository. If you've also specified a non-master branch at this point, it's likely the installation will fail.

Assigning `SWARMLET_REPO` with the `GITHUB_USER` value resolves this issue.